### PR TITLE
Fixed find-all-devs for debian.

### DIFF
--- a/pcap.lisp
+++ b/pcap.lisp
@@ -114,9 +114,31 @@
 
 (defcstruct sockaddr
   "BSD SOCKADDR structure."
-  (sa_len :uint8)
-  (sa_family :uint8)
-  (sa_data :char))
+  (sa_family_len :unsigned-short)
+  (sa_data :char :count 14))
+
+(defcstruct in6_addr
+  "IPv6 address"
+  (s6_addr :uint8 :count 16))
+
+;; from netinet/in.h
+(defcstruct sockaddr_in6
+  "Structure describing an IPv6 socket  address."
+  (int6_family :unsigned-short)
+  (sin6_flowinfo :uint32)
+  (in6_addr (:struct in6_addr))
+  (sin6_scope_id :uint32))
+
+;; from netpacket/packet.h
+(defcstruct sockaddr_ll
+  "A device-independent physical-layer address."
+  (sll_family :unsigned-short)
+  (sll_protocol :unsigned-short)
+  (sll_ifindex :int)
+  (sll_haltype :unsigned-short)
+  (sll_pkttype :unsigned-char)
+  (sll_halen :unsigned-char)
+  (sll_addr :unsigned-char :count 8)) ;/* Physical-layer address */
 
 ;; Missing field for win32
 (defcstruct pcap_stat


### PR DESCRIPTION
On debian stretch, sbcl-1.5.4 find-all-devs now work.

```
CL-USER> (plokami:find-all-devs)
...
 ("enp3s0" NIL 6
  (((:ADDR :AF_INET6 "0:21f:d0ff:feb1:f831:200::")
    (:NETMASK :AF_INET6 "ffff::"))
   ((:ADDR :AF_INET "192.168.4.155") (:NETMASK :AF_INET "255.255.255.0")
    (:BROADADDR :AF_INET "192.168.4.255"))
   ((:ADDR :AF_LINK "00:1F:D0:B1:F8:31")
    (:BROADADDR :AF_LINK "FF:FF:FF:FF:FF:FF")))))
```